### PR TITLE
Change bottom corners roundness.

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values-sw372dp/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values-sw372dp/dimens.xml
@@ -17,5 +17,5 @@
 -->
 <resources>
     <dimen name="rounded_corner_radius_top">90px</dimen>
-    <dimen name="rounded_corner_radius_bottom">30dp</dimen>
+    <dimen name="rounded_corner_radius_bottom">90px</dimen>
 </resources>


### PR DESCRIPTION
It matches the bottom corners with the top ones.
Also, the size should be specified in pixels (not in DP) since this device has physical round corners.